### PR TITLE
Add exec_depend on tango-icon-theme system package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,9 @@
   <author>Stephen Brawner</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>tango-icon-theme</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
This dependency is necessary to ensure the system package is present on platforms where the icons are not vendored.

Here's the rosdep key: https://github.com/ros/rosdistro/blob/e3088365fe264a342390a45da3995114956c048e/rosdep/base.yaml#L6469-L6483

Follow-up to ros-visualization/qt_gui_core#224
Related to ros-visualization/rqt#249